### PR TITLE
Fix ExistingChiller sizing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Classify the change according to the following categories:
 ### Fixed
 - Fixed a bug in which the CHP system requires a **DomesticHotWater** load.
 - Fixed a bug in which the storage to steam turbine flow was included in the thermal heating load served.
+- Switched to use maximum value of **dvCoolingProduction** for **ExistingChiller**'s size instead of **dvSize**. This fixed the issue with **ExistingChiller**'s size being applied **max_thermal_factor_on_peak_load** twice in some cases.
 
 ### Changed
 - **HotThermalStorage** and **HighTempThermalStorage** output **storage_to_turbine_series_mmbtu_per_hour** to **storage_to_steamturbine_series_mmbtu_per_hour**

--- a/src/core/existing_chiller.jl
+++ b/src/core/existing_chiller.jl
@@ -5,7 +5,7 @@
     loads_kw_thermal::Vector{<:Real},
     cop::Union{Real, Nothing} = nothing,
     max_thermal_factor_on_peak_load::Real=1.25
-    installed_cost_per_kw::Real = 0.0  # Represents needed CapEx in BAU, assuming net present value basis based on current size; also incurred in Optimal case if still using at all
+    installed_cost_per_ton::Real = 0.0  # Represents needed CapEx in BAU, assuming net present value basis based on current size; also incurred in Optimal case if still using at all
     installed_cost_dollars::Real = 0.0  # Represents needed CapEx in BAU, assuming net present cost basis; also incurred in Optimal case if still using at all
     retire_in_optimal::Bool = false  # Do NOT use in the optimal case (still used in BAU)
 ```

--- a/src/results/existing_chiller.jl
+++ b/src/results/existing_chiller.jl
@@ -11,7 +11,9 @@
 function add_existing_chiller_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict; _n="")
     r = Dict{String, Any}()
 
-	r["size_ton"] = round(value(m[Symbol("dvSize"*_n)]["ExistingChiller"]) * p.s.existing_chiller.max_thermal_factor_on_peak_load / KWH_THERMAL_PER_TONHOUR, digits=3)
+	max_prod_kw = maximum(value.((m[Symbol("dvCoolingProduction"*_n)]["ExistingChiller",:])))
+	size_actual_ton = max_prod_kw / KWH_THERMAL_PER_TONHOUR * p.s.existing_chiller.max_thermal_factor_on_peak_load
+	r["size_ton"] = round(size_actual_ton, digits=3)
 
 	@expression(m, ELECCHLtoTES[ts in p.time_steps],
 		sum(m[:dvProductionToStorage][b,"ExistingChiller",ts] for b in p.s.storage.types.cold)


### PR DESCRIPTION
### Overview
This PR addresses two issues related to ExistingChiller sizing (https://github.com/NatLabRockies/REopt.jl/issues/569 and https://github.com/NatLabRockies/REopt.jl/issues/568):
- ExistingChiller only applies an extra 1.25 factor on peak to chiller's size in the optimal case when no capital cost is provided. It still only applies the 1.25 factor one time (correctly) in BAU or when capital cost is provided
- Fix: Switch to use `max(dvCoolingProduction)` for chiller's size instead of `dvSize`. I'm unclear why `dvSize` gives a different value than `max(dvCoolingProduction)` in some cases at this point but will look into this more later (issued documented: https://github.com/NatLabRockies/REopt.jl/issues/587).

### Validation
- Test case for a commercial building in Atlanta with both heating and cooling loads. Confirmed that chiller size only applies 1.25 factor ONE TIME across settings (without cap cost, with cap cost, in BAU, in Optimal without GHP deployment).
- Also tested with Amanda's demo case study for a commercial building in Denver where capital cost of ExistingChiller is not provided. Confirmed chiller's size in BAU is the same as in optimal case without GHP deployment.
- Details of results for both of these tests are here https://github.com/atpham88/existing_chiller_debug_REopt/tree/main/results.

### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [ ] Docs have been added / updated if applicable
- [ ] Any new packages have been added to the [compat] section of Project.toml
- [ ] REopt version number is updated in Project.toml and CHANGELOG.md if merging into master (do this right before merging)
- [ ] Tests for the changes have been added. These tests should compare against expected values that are calculated independently of running REopt. Tests should also include garbage collection (see other tests for examples).
- [ ] Any new REopt outputs and required inputs have been added to the corresponding Django model in the REopt API

### Replace this with a description of the changes (can just copy from CHANGELOG.md)
