### PR TITLE
Add Cost to Utility to Objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## cost-to-utility
+### Added
+- Add **ElectricUtility** input field `utility_grid_cost_per_kw_series`. When provided, the TotalUtilityGridCost (lifecycle cost) is included in the LCC and objective function, but IS NOT included in the assumed site energy costs. 
+
 ## v0.59.0
 ### Added
 - Added two new size classes for **SteamTurbine** tech with new tech size ranges.

--- a/src/constraints/load_balance.jl
+++ b/src/constraints/load_balance.jl
@@ -158,6 +158,15 @@ function add_thermal_load_constraints(m, p; _n="")
     end
 end
 
+function calculate_net_load(m, p; _n="")
+    # Calculate net load (grid purchase - production to grid - BESS to grid)
+    @constraint(m, [ts in p.time_steps],
+        m[Symbol("dvNetLoad"*_n)][ts] == sum(m[Symbol("dvGridPurchase"*_n)][ts, tier] for tier in 1:p.s.electric_tariff.n_energy_tiers) 
+        - sum(m[Symbol("dvProductionToGrid"*_n)][t, u, ts] for t in setdiff(p.techs.elec, p.techs.steam_turbine), u in p.export_bins_by_tech[t])
+        - sum(m[Symbol("dvStorageToGrid"*_n)][b, u, ts] for b in p.s.storage.types.elec, u in p.export_bins_by_storage[b])
+    )
+end
+
 function add_absorption_chiller_load_constraints(m,p;_n="")
     if !isempty(p.techs.absorption_chiller)
         for q in p.heating_loads

--- a/src/core/electric_utility.jl
+++ b/src/core/electric_utility.jl
@@ -54,6 +54,9 @@
     ### Grid Clean Energy Fraction Inputs ###
     cambium_cef_metric::String = "cef_load", # Options = ["cef_load", "cef_gen"] # cef_load is the fraction of generation that is clean, for the generation that is allocated to a region’s end-use load; cef_gen is the fraction of generation that is clean within a region
     renewable_energy_fraction_series::Union{Real,Array{<:Real,1}} = Float64[], # Fraction of energy supplied by the grid that is renewable. Can be scalar or timeseries (aligned with time_steps_per_hour)
+
+    # Timeseries grid cost input
+    utility_grid_cost_per_kw_series::Array{<:Real,1} = Float64[] # Timeseries of per kW grid costs (incurred by utility, not the site). # TODO: this should be \$ per kWh like wholesale_rate etc; will require multiplying by hours per timestep somewhere 
 ```
 
 !!! note "Outage modeling"
@@ -113,6 +116,9 @@
             - By default, REopt uses *clean energy fraction* for the region in which the site is located.
     - For sites outside of CONUS: REopt does not have default grid clean energy fraction data. Users must supply a custom `renewable_energy_fraction_series`
 
+    **Utility Grid Costs**
+    - utility_grid_cost_per_kw_series timeseries will be multiplied by the net load in each time step, and the analysis period total grid cost will be calculated using a pwf, assuming costs escalate at the elec_cost_escalation_rate_fraction. 
+    - If provided, total grid cost will be included in the objective function (and impact dispatch)
 """
 struct ElectricUtility
     avert_emissions_region::String # AVERT emissions region
@@ -140,6 +146,7 @@ struct ElectricUtility
     net_metering_limit_kw::Real 
     interconnection_limit_kw::Real 
     transmission_limit_kw::Real
+    utility_grid_cost_per_kw_series::Array{<:Real,1}
 
 
     function ElectricUtility(;
@@ -199,6 +206,9 @@ struct ElectricUtility
         ### Grid Clean Energy Fraction Inputs ###
         cambium_cef_metric::String = "cef_load", # Options = ["cef_load", "cef_gen"] # cef_load is the fraction of generation that is clean, for the generation that is allocated to a region’s end-use load; cef_gen is the fraction of generation that is clean within a region
         renewable_energy_fraction_series::Union{Real,Array{<:Real,1}} = Float64[], # Fraction of energy supplied by the grid that is renewable. Can be scalar or timeseries (aligned with time_steps_per_hour)
+
+        # Timeseries grid cost input
+        utility_grid_cost_per_kw_series::Array{<:Real,1} = Float64[] # Timeseries of per kW grid costs (incurred by utility, not the site).
         )
 
         is_MPC = isnothing(latitude) || isnothing(longitude)
@@ -346,6 +356,10 @@ struct ElectricUtility
             throw(@error("Sum of ElectricUtility inputs outage_probabilities must be equal to 1"))
         end
 
+        if !isempty(utility_grid_cost_per_kw_series) && length(utility_grid_cost_per_kw_series) != 8760*time_steps_per_hour
+            throw(@error("Length of utility_grid_cost_per_kw_series must be $(8760*time_steps_per_hour)."))
+        end
+
         new(
             is_MPC ? "" : avert_emissions_region,
             is_MPC || isnothing(meters_to_region) ? typemax(Int64) : meters_to_region,
@@ -369,7 +383,8 @@ struct ElectricUtility
             scenarios,
             net_metering_limit_kw,
             interconnection_limit_kw,
-            transmission_limit_kw
+            transmission_limit_kw,
+            utility_grid_cost_per_kw_series
         )
     end
 end

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -260,6 +260,7 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 	m[:ExistingChillerCost] = 0.0
 	m[:ElectricStorageCapCost] = 0.0
 	m[:ElectricStorageOMCost] = 0.0
+	m[:TotalUtilityGridCost] = 0.0
 
 	if !isempty(p.techs.all) || !isempty(p.techs.ghp)
 		if !isempty(p.techs.all)
@@ -502,6 +503,12 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 		add_capex_constraints(m, p)
 	end
 
+	# Calculate total grid cost based on utility grid cost per kW series and net load 
+	if !isempty(p.s.electric_utility.utility_grid_cost_per_kw_series)
+		calculate_net_load(m, p)
+		m[:TotalUtilityGridCost] = p.pwf_e * sum(p.s.electric_utility.utility_grid_cost_per_kw_series .* m[:dvNetLoad])
+	end
+
 	#################################  Objective Function   ########################################
 	@expression(m, Costs,
 		# Capital Costs
@@ -535,7 +542,10 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 		m[:AvoidedCapexByGHP] - m[:ResidualGHXCapCost] - 
 
 		# Subtract capital expenditures avoided by inclusion of ASHP
-		m[:AvoidedCapexByASHP]
+		m[:AvoidedCapexByASHP]+ 
+
+		# Add utility grid cost (not incurred by customer) - only nonzero if utility_grid_cost_per_kw_series provided
+		m[:TotalUtilityGridCost]
 
 	);
 	if !isempty(p.s.electric_utility.outage_durations)

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -163,6 +163,7 @@ function dictkeys_tosymbols(d::Dict)
             "grid_draw_limit_kw_by_time_step", "export_limit_kw_by_time_step",
             "outage_probabilities",
             "renewable_energy_fraction_series",
+            "utility_grid_cost_per_kw_series",
             "heating_cop_reference",
             "heating_cf_reference",
             "heating_reference_temps_degF",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] CHANGELOG.md is updated
- [ ] Docs have been added / updated if applicable
- [ ] Any new packages have been added to the [compat] section of Project.toml
- [ ] REopt version number is updated in Project.toml and CHANGELOG.md if merging into master (do this right before merging)
- [ ] Tests for the changes have been added. These tests should compare against expected values that are calculated independently of running REopt. Tests should also include garbage collection (see other tests for examples).
- [ ] Any new REopt outputs and required inputs have been added to the corresponding Django model in the REopt API

### Added
- Add **ElectricUtility** input field `utility_grid_cost_per_kw_series`. When provided, the TotalUtilityGridCost (lifecycle cost) is included in the LCC and objective function, but IS NOT included in the assumed site energy costs. 
