### PR TITLE
Allow SteamTurbine in electric-only scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Classify the change according to the following categories:
     ### Deprecated
     ### Removed
 
+## feature/steam-turbine-electric-only
+### Fixed
+- `src`, `test` Allow a **Boiler** to supply a condensing **SteamTurbine** in electric-only scenarios without a site heating load.
+
 ## v0.61.1
 ### Fixed
 - Avoid double-multiplication of production_factor_series with electrical load-following

--- a/src/core/boiler.jl
+++ b/src/core/boiler.jl
@@ -29,7 +29,8 @@ end
 When modeling a heating load an `ExistingBoiler` model is created even if user does not provide the
 `ExistingBoiler` key. The `Boiler` model is not created by default. If a user provides the `Boiler`
 key then the optimal scenario has the option to purchase this new `Boiler` to meet the heating load
-in addition to using the `ExistingBoiler` to meet the heating load. 
+in addition to using the `ExistingBoiler`. A `Boiler` can also be modeled without a site heating load
+when a `SteamTurbine` is included and `can_supply_steam_turbine` is `true`.
 
 ```julia
 function Boiler(;
@@ -79,7 +80,7 @@ function Boiler(;
     )
 
     if isempty(fuel_cost_per_mmbtu)
-        throw(@error("The Boiler.fuel_cost_per_mmbtu is a required input when modeling a heating load which is served by the Boiler in the optimal case"))
+        throw(@error("Boiler.fuel_cost_per_mmbtu is required when modeling a Boiler."))
     end
 
     min_kw = min_mmbtu_per_hour * KWH_PER_MMBTU

--- a/src/core/scenario.jl
+++ b/src/core/scenario.jl
@@ -418,10 +418,12 @@ function Scenario(d::Dict; flex_hvac_from_json=false)
     end
 
     if haskey(d, "Boiler")
-        if max_heat_demand_kw > 0 && !haskey(d, "FlexibleHVAC")
+        boiler_can_supply_steam_turbine = haskey(d, "SteamTurbine") &&
+            get(d["Boiler"], "can_supply_steam_turbine", true)
+        if (max_heat_demand_kw > 0 || boiler_can_supply_steam_turbine) && !haskey(d, "FlexibleHVAC")
             boiler = Boiler(; dictkeys_tosymbols(d["Boiler"])...)
         end
-        if !(max_heat_demand_kw > 0) && !haskey(d, "FlexibleHVAC")
+        if !(max_heat_demand_kw > 0 || boiler_can_supply_steam_turbine) && !haskey(d, "FlexibleHVAC")
             @warn("Not creating Boiler because there is no heating load.")
         end
     end

--- a/src/core/techs.jl
+++ b/src/core/techs.jl
@@ -371,16 +371,16 @@ function Techs(s::Scenario)
     end
 
     # Zero out can_serve_* lists when the corresponding load is zero,
-    # UNLESS AbsorptionChiller is using that heating quality as its heat source
-    # (in which case techs must remain available to supply heat to the AC even though direct load is zero).
+    # UNLESS AbsorptionChiller or SteamTurbine is using heating production
+    # (in which case techs must remain available even though direct load is zero).
     ac_heating_load = !isnothing(s.absorption_chiller) ? s.absorption_chiller.heating_load_input : nothing
-    if sum(s.dhw_load.loads_kw) == 0.0 && ac_heating_load != "DomesticHotWater"
+    if sum(s.dhw_load.loads_kw) == 0.0 && ac_heating_load != "DomesticHotWater" && isnothing(s.steam_turbine)
         techs_can_serve_dhw = String[]
     end
-    if sum(s.space_heating_load.loads_kw) == 0.0 && ac_heating_load != "SpaceHeating"
+    if sum(s.space_heating_load.loads_kw) == 0.0 && ac_heating_load != "SpaceHeating" && isnothing(s.steam_turbine)
         techs_can_serve_space_heating = String[]
     end
-    if sum(s.process_heat_load.loads_kw) == 0.0 && ac_heating_load != "ProcessHeat"
+    if sum(s.process_heat_load.loads_kw) == 0.0 && ac_heating_load != "ProcessHeat" && isnothing(s.steam_turbine)
         techs_can_serve_process_heat = String[]
     end
 

--- a/src/results/heating_cooling_load.jl
+++ b/src/results/heating_cooling_load.jl
@@ -94,7 +94,12 @@ function add_heating_load_results(m::JuMP.AbstractModel, p::REoptInputs, d::Dict
                                                     p.s.space_heating_load.unaddressable_annual_fuel_mmbtu + 
                                                     p.s.process_heat_load.unaddressable_annual_fuel_mmbtu)
 
-    r["annual_emissions_from_unaddressable_heating_load_tonnes_CO2"] = r["annual_total_unaddressable_heating_load_mmbtu"] * p.s.existing_boiler.emissions_factor_lb_CO2_per_mmbtu * TONNE_PER_LB
+    if r["annual_total_unaddressable_heating_load_mmbtu"] > 0.0
+        r["annual_emissions_from_unaddressable_heating_load_tonnes_CO2"] =
+            r["annual_total_unaddressable_heating_load_mmbtu"] * p.s.existing_boiler.emissions_factor_lb_CO2_per_mmbtu * TONNE_PER_LB
+    else
+        r["annual_emissions_from_unaddressable_heating_load_tonnes_CO2"] = 0.0
+    end
 
     d["HeatingLoad"] =   r
     nothing

--- a/src/results/results.jl
+++ b/src/results/results.jl
@@ -72,11 +72,12 @@ function reopt_results(m::JuMP.AbstractModel, p::REoptInputs; _n="")
         add_heating_load_results(m, p, d)
     end
 
-    if !isempty(p.techs.boiler)
+    if "ExistingBoiler" in p.techs.boiler
         add_existing_boiler_results(m, p, d)
-        if "Boiler" in p.techs.boiler
-            add_boiler_results(m, p, d)
-        end
+    end
+
+    if "Boiler" in p.techs.boiler
+        add_boiler_results(m, p, d)
     end
 
     if _n==""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2581,6 +2581,51 @@ else  # run HiGHS tests
             boiler_to_st = sum(results["Boiler"]["thermal_to_steamturbine_series_mmbtu_per_hour"])
             st_thermal_in = results["SteamTurbine"]["annual_thermal_consumption_mmbtu"]
             @test boiler_to_st ≈ st_thermal_in rtol=0.01
+
+            finalize(backend(m1))
+            empty!(m1)
+            finalize(backend(m2))
+            empty!(m2)
+
+            # A condensing SteamTurbine can produce electricity from a Boiler without a site heating load.
+            delete!(input_data, "SpaceHeatingLoad")
+            delete!(input_data, "DomesticHotWaterLoad")
+            input_data["SteamTurbine"]["min_kw"] = 30.0
+            input_data["SteamTurbine"]["max_kw"] = 30.0
+            input_data["SteamTurbine"]["is_condensing"] = true
+            input_data["SteamTurbine"]["thermal_produced_to_thermal_consumed_ratio"] = 0.0
+            input_data["SteamTurbine"]["installed_cost_per_kw"] = 0.0
+            input_data["SteamTurbine"]["om_cost_per_kw"] = 0.0
+            input_data["SteamTurbine"]["om_cost_per_kwh"] = 0.0
+            input_data["Boiler"]["fuel_cost_per_mmbtu"] = 1.0
+            input_data["Boiler"]["installed_cost_per_mmbtu_per_hour"] = 0.0
+            input_data["Boiler"]["om_cost_per_mmbtu_per_hour"] = 0.0
+            input_data["Boiler"]["om_cost_per_mmbtu"] = 0.0
+
+            electric_only_scenario = Scenario(input_data)
+            electric_only_inputs = REoptInputs(electric_only_scenario)
+            @test electric_only_scenario.boiler.max_kw > 0.0
+            @test "Boiler" in electric_only_inputs.techs.can_supply_steam_turbine
+
+            m3 = Model(optimizer_with_attributes(HiGHS.Optimizer, "mip_rel_gap" => 0.001, "output_flag" => false, "log_to_console" => false))
+            electric_only_results = run_reopt(m3, electric_only_inputs)
+
+            expected_electric_kwh = 30.0 * 8760
+            expected_thermal_input_mmbtu = expected_electric_kwh /
+                input_data["SteamTurbine"]["electric_produced_to_thermal_consumed_ratio"] / REopt.KWH_PER_MMBTU
+            expected_boiler_fuel_mmbtu = expected_thermal_input_mmbtu / input_data["Boiler"]["efficiency"]
+
+            @test electric_only_results["status"] == "optimal"
+            @test electric_only_results["SteamTurbine"]["annual_electric_production_kwh"] ≈ expected_electric_kwh rtol=1e-5
+            @test electric_only_results["SteamTurbine"]["annual_thermal_consumption_mmbtu"] ≈ expected_thermal_input_mmbtu rtol=1e-5
+            @test electric_only_results["Boiler"]["annual_fuel_consumption_mmbtu"] ≈ expected_boiler_fuel_mmbtu rtol=0.002
+            @test sum(electric_only_results["Boiler"]["thermal_to_steamturbine_series_mmbtu_per_hour"]) ≈ expected_thermal_input_mmbtu rtol=0.002
+            @test sum(electric_only_results["Boiler"]["thermal_to_load_series_mmbtu_per_hour"]) ≈ 0.0 atol=1e-5
+            @test sum(electric_only_results["SteamTurbine"]["thermal_to_load_series_mmbtu_per_hour"]) ≈ 0.0 atol=1e-5
+
+            finalize(backend(m3))
+            empty!(m3)
+            GC.gc()
         end        
 
         @testset "OffGrid" begin


### PR DESCRIPTION
## Summary

- keep a user-supplied Boiler available when it can supply a SteamTurbine without a site heating load
- preserve the heating-production pathway required for Boiler-to-SteamTurbine dispatch and support results when no ExistingBoiler is modeled
- document the behavior and add a condensing SteamTurbine regression with independently calculated electricity, thermal-input, and fuel-use expectations

Closes #493

## Validation

- focused Julia 1.10.11 + HiGHS electric-only regression: 9/9 assertions passed
- existing Boiler/SteamTurbine scenario: 4/4 assertions passed
- test/runtests.jl syntax parse
- git diff --check

## Checklist

- [x] CHANGELOG.md is updated
- [x] Documentation is updated
- [x] No new packages are introduced
- [x] Tests compare against independently calculated expected values and include model cleanup and garbage collection
- [x] No new REopt inputs or outputs require Django model changes
- [x] Version bump reviewed and intentionally deferred until immediately before merge, per the repository template
